### PR TITLE
Fix handler registration condition

### DIFF
--- a/src/main/java/com/nexost/experiments/kafka/handlers/ListenerHandlerManager.java
+++ b/src/main/java/com/nexost/experiments/kafka/handlers/ListenerHandlerManager.java
@@ -14,7 +14,11 @@ public class ListenerHandlerManager {
 	
 	private static List<ListenerHandler> handlers = new ArrayList<ListenerHandler>();
 
-	@StreamListener(target = Sink.INPUT, condition = "headers['type']=='bogey'")
+    // The sender places the message type under the 'messageType' header.
+    // Using 'type' here prevents the listener from receiving any messages
+    // because the condition never matches. Adjust the header name so that
+    // incoming messages are correctly routed to the registered handlers.
+    @StreamListener(target = Sink.INPUT, condition = "headers['messageType']=='bogey'")
 	public static void messageReceived(String message) {
 		
 		for (ListenerHandler listenerHandler : handlers) {


### PR DESCRIPTION
## Summary
- adjust `ListenerHandlerManager` condition to use correct header

## Testing
- `mvn -q test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4c347b8832eb1c79c4e0f267e96